### PR TITLE
Relax aeson dependency, so that package can be installed alongside servant

### DIFF
--- a/users/users.cabal
+++ b/users/users.cabal
@@ -1,5 +1,5 @@
 name:                users
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            A library simplifying user management for web applications
 description:         Scrap the boilerplate for managing user accounts in web applications
                      .
@@ -37,7 +37,7 @@ source-repository head
 library
   exposed-modules:     Web.Users.Types
   build-depends:
-                       aeson >=0.8,
+                       aeson >=0.7,
                        base >=4.6 && <5,
                        bcrypt >=0.0.6,
                        path-pieces >=0.1,


### PR DESCRIPTION
Trying to install both users and servant-server leads to cabal dependency issues; relaxing the aeson dependency solves this problem.
