### PR TITLE
Add alternative auth functions

### DIFF
--- a/users-postgresql-simple/src/Web/Users/Postgresql.hs
+++ b/users-postgresql-simple/src/Web/Users/Postgresql.hs
@@ -108,6 +108,14 @@ instance UserStorageBackend Connection where
     housekeepBackend conn =
         do _ <- execute_ conn [sql|DELETE FROM login_token WHERE valid_until < NOW();|]
            return ()
+    -- | Retrieve a user id from the database
+    getUserIdByName conn username =
+        do resultSet <-
+               query conn [sql|SELECT lid FROM login WHERE username = ? LIMIT 1;|] (Only username)
+           case resultSet of
+             [(Only userId)] ->
+                 return $ Just userId
+             _ -> return Nothing
     getUserById conn userId =
         do resultSet <-
                query conn [sql|SELECT username, email, is_active, more FROM login WHERE lid = ? LIMIT 1;|] (Only userId)

--- a/users-postgresql-simple/users-postgresql-simple.cabal
+++ b/users-postgresql-simple/users-postgresql-simple.cabal
@@ -1,5 +1,5 @@
 name:                users-postgresql-simple
-version:             0.2.0.2
+version:             0.3.0.0
 synopsis:            A PostgreSQL backend for the users package
 description:         This library is a backend driver using <http://hackage.haskell.org/package/postgresql-simple postgresql-simple> for
                      <http://hackage.haskell.org/package/users the "users" library>.
@@ -33,7 +33,7 @@ library
   exposed-modules:     Web.Users.Postgresql
   build-depends:
                        base >=4.6 && <5,
-                       users >=0.2.0.2,
+                       users >=0.3.0.0,
                        postgresql-simple >=0.4,
                        aeson >=0.7,
                        text >=1.2,

--- a/users-postgresql-simple/users-postgresql-simple.cabal
+++ b/users-postgresql-simple/users-postgresql-simple.cabal
@@ -1,5 +1,5 @@
 name:                users-postgresql-simple
-version:             0.2.0.0
+version:             0.2.0.2
 synopsis:            A PostgreSQL backend for the users package
 description:         This library is a backend driver using <http://hackage.haskell.org/package/postgresql-simple postgresql-simple> for
                      <http://hackage.haskell.org/package/users the "users" library>.
@@ -33,9 +33,9 @@ library
   exposed-modules:     Web.Users.Postgresql
   build-depends:
                        base >=4.6 && <5,
-                       users >=0.2,
+                       users >=0.2.0.2,
                        postgresql-simple >=0.4,
-                       aeson >=0.8,
+                       aeson >=0.7,
                        text >=1.2,
                        mtl >=2.1,
                        uuid >=1.3,

--- a/users-test/src/Web/Users/TestSpec.hs
+++ b/users-test/src/Web/Users/TestSpec.hs
@@ -94,6 +94,8 @@ makeUsersSpec backend =
                                     { dd_foo = False
                                     }
                                 })
+                        userIdA' <- getUserIdByName backend "changed"
+                        userIdA' `shouldBe` Just userIdA
               it "deleting users should work" $
                  assertRight (createUser backend userA) $ \userIdA ->
                  assertRight (createUser backend userB) $ \userIdB ->
@@ -123,6 +125,31 @@ makeUsersSpec backend =
                     authUser backend "bar@baz.com" (PasswordPlain "123") 500 `shouldReturn` Nothing
                     authUser backend "bar@baz.com' OR 1 = 1 --" (PasswordPlain "123") 500 `shouldReturn` Nothing
                     authUser backend "bar@baz.com' OR 1 = 1; --" (PasswordPlain  "' OR 1 = 1; --") 500 `shouldReturn` Nothing
+              it "sessionless auth as valid user with username should work" $
+                 assertRight (createUser backend userA) $ \userIdA ->
+                 do withAuthUser backend "bar@baz.com" (PasswordPlain "1234") (return . (== userIdA)) `shouldReturn` Just True
+                    withAuthUser backend "bar@baz.com" (PasswordPlain "1234") (return . (/= userIdA)) `shouldReturn` Just False
+              it "sessionless auth with invalid credentials should fail" $
+                 assertRight (createUser backend userA) $ \userIdA ->
+                    withAuthUser backend "bar@baz.com" (PasswordPlain "xxxx") (return . (== userIdA)) `shouldReturn` Nothing
+              it "auth with valid userdata should work" $
+                 assertRight (createUser backend userA) $ \userIdA ->
+                 do mAuthRes <- authUserByUserData backend "bar@baz.com" (== DummyDetails True 21) 500
+                    case mAuthRes of
+                      Nothing ->
+                          expectationFailure $ "Can not authenticate by userdata"
+                      Just sessionId ->
+                          do verifySession backend sessionId 500 `shouldReturn` Just userIdA
+              it "auth with invalid userdata should fail" $
+                 assertRight (createUser backend userA) $ \userIdA ->
+                    authUserByUserData backend "bar@baz.com" (/= DummyDetails True 21) 0 `shouldReturn` Nothing
+              it "sessionless auth with valid userdata should work" $
+                 assertRight (createUser backend userA) $ \userIdA ->
+                 do withAuthUserByUserData backend "bar@baz.com" (== DummyDetails True 21) (return . (== userIdA)) `shouldReturn` Just True
+                    withAuthUserByUserData backend "bar@baz.com" (== DummyDetails True 21) (return . (/= userIdA)) `shouldReturn` Just False
+              it "sessionless auth with invalid userdata should fail" $
+                 assertRight (createUser backend userA) $ \userIdA ->
+                    withAuthUserByUserData backend "bar@baz.com" (/= DummyDetails True 21) (return . (/= userIdA)) `shouldReturn` Nothing
               it "destroy session should really remove the session" $
                  withAuthedUser $ \(sessionId, _) ->
                      do destroySession backend sessionId

--- a/users-test/src/Web/Users/TestSpec.hs
+++ b/users-test/src/Web/Users/TestSpec.hs
@@ -125,31 +125,13 @@ makeUsersSpec backend =
                     authUser backend "bar@baz.com" (PasswordPlain "123") 500 `shouldReturn` Nothing
                     authUser backend "bar@baz.com' OR 1 = 1 --" (PasswordPlain "123") 500 `shouldReturn` Nothing
                     authUser backend "bar@baz.com' OR 1 = 1; --" (PasswordPlain  "' OR 1 = 1; --") 500 `shouldReturn` Nothing
-              it "sessionless auth as valid user with username should work" $
-                 assertRight (createUser backend userA) $ \userIdA ->
-                 do withAuthUser backend "bar@baz.com" (PasswordPlain "1234") (return . (== userIdA)) `shouldReturn` Just True
-                    withAuthUser backend "bar@baz.com" (PasswordPlain "1234") (return . (/= userIdA)) `shouldReturn` Just False
-              it "sessionless auth with invalid credentials should fail" $
-                 assertRight (createUser backend userA) $ \userIdA ->
-                    withAuthUser backend "bar@baz.com" (PasswordPlain "xxxx") (return . (== userIdA)) `shouldReturn` Nothing
-              it "auth with valid userdata should work" $
-                 assertRight (createUser backend userA) $ \userIdA ->
-                 do mAuthRes <- authUserByUserData backend "bar@baz.com" (== DummyDetails True 21) 500
-                    case mAuthRes of
-                      Nothing ->
-                          expectationFailure $ "Can not authenticate by userdata"
-                      Just sessionId ->
-                          do verifySession backend sessionId 500 `shouldReturn` Just userIdA
-              it "auth with invalid userdata should fail" $
-                 assertRight (createUser backend userA) $ \userIdA ->
-                    authUserByUserData backend "bar@baz.com" (/= DummyDetails True 21) 0 `shouldReturn` Nothing
               it "sessionless auth with valid userdata should work" $
                  assertRight (createUser backend userA) $ \userIdA ->
-                 do withAuthUserByUserData backend "bar@baz.com" (== DummyDetails True 21) (return . (== userIdA)) `shouldReturn` Just True
-                    withAuthUserByUserData backend "bar@baz.com" (== DummyDetails True 21) (return . (/= userIdA)) `shouldReturn` Just False
+                 do withAuthUser backend "bar@baz.com" ((== DummyDetails True 21) . u_more) (return . (== userIdA)) `shouldReturn` Just True
+                    withAuthUser backend "bar@baz.com" ((== DummyDetails True 21) . u_more) (return . (/= userIdA)) `shouldReturn` Just False
               it "sessionless auth with invalid userdata should fail" $
                  assertRight (createUser backend userA) $ \userIdA ->
-                    withAuthUserByUserData backend "bar@baz.com" (/= DummyDetails True 21) (return . (/= userIdA)) `shouldReturn` Nothing
+                    withAuthUser backend "bar@baz.com" ((/= DummyDetails True 21) . u_more) (return . (/= userIdA)) `shouldReturn` Nothing
               it "destroy session should really remove the session" $
                  withAuthedUser $ \(sessionId, _) ->
                      do destroySession backend sessionId

--- a/users-test/users-test.cabal
+++ b/users-test/users-test.cabal
@@ -1,5 +1,5 @@
 name:                users-test
-version:             0.2.0.0
+version:             0.2.0.2
 synopsis:            Library to test backends for the users library
 description:         Provides HSpec helpers for backends of <http://hackage.haskell.org/package/users users package>.
                      .
@@ -26,7 +26,7 @@ library
                        aeson >=0.8,
                        base >=4.6 && <5,
                        hspec >=2.1,
-                       users >=0.2,
+                       users >=0.2.0.2,
                        text >=1.2
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/users-test/users-test.cabal
+++ b/users-test/users-test.cabal
@@ -1,5 +1,5 @@
 name:                users-test
-version:             0.2.0.2
+version:             0.3.0.0
 synopsis:            Library to test backends for the users library
 description:         Provides HSpec helpers for backends of <http://hackage.haskell.org/package/users users package>.
                      .
@@ -26,7 +26,7 @@ library
                        aeson >=0.8,
                        base >=4.6 && <5,
                        hspec >=2.1,
-                       users >=0.2.0.2,
+                       users >=0.3.0.0,
                        text >=1.2
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/users/src/Web/Users/Types.hs
+++ b/users/src/Web/Users/Types.hs
@@ -84,12 +84,8 @@ class (Show (UserId b), Eq (UserId b), ToJSON (UserId b), FromJSON (UserId b), T
     deleteUser :: b -> UserId b -> IO ()
     -- | Authentificate a user using username/email and password. The 'NominalDiffTime' describes the session duration
     authUser :: b -> T.Text -> PasswordPlain -> NominalDiffTime -> IO (Maybe SessionId)
-    -- | Authentificate a user using username/email and password and execute a single action.
-    withAuthUser :: b -> T.Text -> PasswordPlain -> (UserId b -> IO r) -> IO (Maybe r)
-    -- | Authentificate a user using the additional info stored in the user record. The 'NominalDiffTime' describes the session duration
-    authUserByUserData :: FromJSON a => b -> T.Text -> (a -> Bool) -> NominalDiffTime -> IO (Maybe SessionId)
-    -- | Authentificate a user using the additional info stored in the user record and execute a single action.
-    withAuthUserByUserData :: FromJSON a => b -> T.Text -> (a -> Bool) -> (UserId b -> IO r) -> IO (Maybe r)
+    -- | Authentificate a user and execute a single action.
+    withAuthUser :: FromJSON a => b -> T.Text -> (User a -> Bool) -> (UserId b -> IO r) -> IO (Maybe r)
     -- | Verify a 'SessionId'. The session duration can be extended by 'NominalDiffTime'
     verifySession :: b -> SessionId -> NominalDiffTime -> IO (Maybe (UserId b))
     -- | Destroy a session

--- a/users/src/Web/Users/Types.hs
+++ b/users/src/Web/Users/Types.hs
@@ -82,8 +82,12 @@ class (Show (UserId b), Eq (UserId b), ToJSON (UserId b), FromJSON (UserId b), T
     deleteUser :: b -> UserId b -> IO ()
     -- | Authentificate a user using username/email and password. The 'NominalDiffTime' describes the session duration
     authUser :: b -> T.Text -> PasswordPlain -> NominalDiffTime -> IO (Maybe SessionId)
+    -- | Authentificate a user using username/email and password and execute a single action.
+    withAuthUser :: b -> T.Text -> PasswordPlain -> (UserId b -> IO r) -> IO (Maybe r)
     -- | Authentificate a user using the additional info stored in the user record. The 'NominalDiffTime' describes the session duration
     authUserByUserData :: FromJSON a => b -> T.Text -> (a -> Bool) -> NominalDiffTime -> IO (Maybe SessionId)
+    -- | Authentificate a user using the additional info stored in the user record and execute a single action.
+    withAuthUserByUserData :: FromJSON a => b -> T.Text -> (a -> Bool) -> (UserId b -> IO r) -> IO (Maybe r)
     -- | Verify a 'SessionId'. The session duration can be extended by 'NominalDiffTime'
     verifySession :: b -> SessionId -> NominalDiffTime -> IO (Maybe (UserId b))
     -- | Destroy a session

--- a/users/src/Web/Users/Types.hs
+++ b/users/src/Web/Users/Types.hs
@@ -58,6 +58,8 @@ class (Show (UserId b), Eq (UserId b), ToJSON (UserId b), FromJSON (UserId b), T
     destroyUserBackend :: b -> IO ()
     -- | This cleans up invalid sessions and other tokens. Call periodically as needed.
     housekeepBackend :: b -> IO ()
+    -- | Retrieve a user id from the database
+    getUserIdByName :: b -> T.Text -> IO (Maybe (UserId b))
     -- | Retrieve a user from the database
     getUserById :: (FromJSON a, ToJSON a) => b -> UserId b -> IO (Maybe (User a))
     -- | List all users (unlimited, or limited)

--- a/users/src/Web/Users/Types.hs
+++ b/users/src/Web/Users/Types.hs
@@ -82,6 +82,8 @@ class (Show (UserId b), Eq (UserId b), ToJSON (UserId b), FromJSON (UserId b), T
     deleteUser :: b -> UserId b -> IO ()
     -- | Authentificate a user using username/email and password. The 'NominalDiffTime' describes the session duration
     authUser :: b -> T.Text -> PasswordPlain -> NominalDiffTime -> IO (Maybe SessionId)
+    -- | Authentificate a user using the additional info stored in the user record. The 'NominalDiffTime' describes the session duration
+    authUserByUserData :: FromJSON a => b -> T.Text -> (a -> Bool) -> NominalDiffTime -> IO (Maybe SessionId)
     -- | Verify a 'SessionId'. The session duration can be extended by 'NominalDiffTime'
     verifySession :: b -> SessionId -> NominalDiffTime -> IO (Maybe (UserId b))
     -- | Destroy a session

--- a/users/users.cabal
+++ b/users/users.cabal
@@ -1,5 +1,5 @@
 name:                users
-version:             0.2.0.1
+version:             0.2.0.2
 synopsis:            A library simplifying user management for web applications
 description:         Scrap the boilerplate for managing user accounts in web applications
                      .

--- a/users/users.cabal
+++ b/users/users.cabal
@@ -1,5 +1,5 @@
 name:                users
-version:             0.2.0.2
+version:             0.3.0.0
 synopsis:            A library simplifying user management for web applications
 description:         Scrap the boilerplate for managing user accounts in web applications
                      .


### PR DESCRIPTION
For a project of mine I needed to add the following functionality:

`getUserIdByName` - gets the user id by username alone, no auth needed. Useful when resetting a password by username.
`withAuth*` functions - sessionless auth, useful whenever the backend just needs to perform a quick action with an authenticated user without a session token.
`*byUserData` functions - useful for alternative auth forms, i.e. pubkey authentication stored in the user data.

I also added some tests that should cover the obvious cases.

Would you be willing to merge? Let me know if you want me to change something.
