### PR TITLE
User error ambiguity

### DIFF
--- a/users-test/src/Web/Users/TestSpec.hs
+++ b/users-test/src/Web/Users/TestSpec.hs
@@ -60,13 +60,13 @@ makeUsersSpec backend =
                  assertRight (createUser backend userB) $ \_ ->
                      do assertLeft (createUser backend (mkUser "foo2" "bar2@baz.com"))
                                        "succeeded to create foo2 bar2 again" $ \err ->
-                            err `shouldBe` UsernameOrEmailAlreadyTaken
+                            err `shouldBe` UsernameAndEmailAlreadyTaken
                         assertLeft (createUser backend (mkUser "foo2" "asdas@baz.com"))
                                        "succeeded to create foo2 with different email again" $ \err ->
-                            err `shouldBe` UsernameOrEmailAlreadyTaken
+                            err `shouldBe` UsernameAlreadyTaken
                         assertLeft (createUser backend (mkUser "asdas" "bar2@baz.com"))
                                        "succeeded to create different user with same email" $ \err ->
-                            err `shouldBe` UsernameOrEmailAlreadyTaken
+                            err `shouldBe` EmailAlreadyTaken
               it "list and count should be correct" $
                  assertRight (createUser backend userA) $ \userId1 ->
                  assertRight (createUser backend userB) $ \userId2 ->
@@ -80,10 +80,10 @@ makeUsersSpec backend =
                      do assertRight (updateUser backend userIdA (\(user :: DummyUser) -> user { u_name = "changed" })) $ const (return ())
                         assertLeft (updateUser backend userIdA (\(user :: DummyUser) -> user { u_name = "foo2" }))
                                        "succeeded to set username to already used username" $ \err ->
-                            err `shouldBe` UsernameOrEmailAlreadyExists
+                            err `shouldBe` UsernameAlreadyExists
                         assertLeft (updateUser backend userIdA (\(user :: DummyUser) -> user { u_email = "bar2@baz.com" }))
                                        "succeeded to set email to already used email" $ \err ->
-                            err `shouldBe` UsernameOrEmailAlreadyExists
+                            err `shouldBe` EmailAlreadyExists
                         updateUserDetails backend userIdA (\d -> d { dd_foo = False })
                         userA' <- getUserById backend userIdA
                         userA' `shouldBe`

--- a/users/src/Web/Users/Types.hs
+++ b/users/src/Web/Users/Types.hs
@@ -30,16 +30,27 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified System.IO.Unsafe as U
 
+{-# DEPRECATED UsernameOrEmailAlreadyTaken "Please use the more specific error constructors." #-}
+
 -- | Errors that happen on storage level during user creation
 data CreateUserError
    = UsernameOrEmailAlreadyTaken
    | InvalidPassword
+   | UsernameAlreadyTaken
+   | EmailAlreadyTaken
+   | UsernameAndEmailAlreadyTaken
    deriving (Show, Eq)
+
+{-# DEPRECATED UsernameOrEmailAlreadyExists "Please use the more descriptive constructors instead." #-}
+{-# DEPRECATED UserDoesntExit "Please use UserDoesntExist instead." #-}
 
 -- | Errors that happen on storage level during user updating
 data UpdateUserError
    = UsernameOrEmailAlreadyExists
+   | UsernameAlreadyExists
+   | EmailAlreadyExists
    | UserDoesntExit
+   | UserDoesntExist
    deriving (Show, Eq)
 
 -- | Errors that happen on storage level during token actions


### PR DESCRIPTION
This PR makes the error constructors more specific in the API. Old errors are deprecated and kept for backwards compatibility. I've updated the client libraries and the test suite to reflect this change.

Fixes #9 
