### PR TITLE
Remove invalid pg limit#,#

### DIFF
--- a/users-postgresql-simple/src/Web/Users/Postgresql.hs
+++ b/users-postgresql-simple/src/Web/Users/Postgresql.hs
@@ -138,7 +138,7 @@ instance UserStorageBackend Connection where
                    case mLimit of
                      Nothing -> ""
                      Just (start, count) ->
-                         (Query $ BSC.pack $ " LIMIT " ++ show start ++ ", " ++ show count)
+                         (Query $ BSC.pack $ " OFFSET " ++ show start ++ " LIMIT " ++ show count)
                sortPart =
                    Query $ " " <> getOrderBy sortField <> " "
                baseQuery =

--- a/users-test/src/Web/Users/TestSpec.hs
+++ b/users-test/src/Web/Users/TestSpec.hs
@@ -62,7 +62,7 @@ makeUsersSpec backend =
               it "list and count should be correct" $
                  assertRight (createUser backend userA) $ \userId1 ->
                  assertRight (createUser backend userB) $ \userId2 ->
-                 do allUsers <- listUsers backend Nothing (SortAsc UserFieldId)
+                 do allUsers <- listUsers backend (Just (0,10)) (SortAsc UserFieldId)
                     unless ((userId1, hidePassword userA) `elem` allUsers && (userId2, hidePassword userB) `elem` allUsers)
                            (expectationFailure $ "create users not in user list:" ++ show allUsers)
                     countUsers backend `shouldReturn` 2


### PR DESCRIPTION
Master currently yields the following error when trying to use `listUsers` with the `users-postgresql-simple` backend:

``` haskell
SqlError {sqlState = "42601", sqlExecStatus = FatalError, sqlErrorMsg = "LIMIT #,# syntax is not supported", sqlErrorDetail = "", sqlErrorHint = "Use separate LIMIT and OFFSET clauses."}
```

This PR changes the definition of `listUsers` to use separate `LIMIT` and `OFFSET` clauses, which works as expected.
