### PR TITLE
In users-postgres-simple, check if the uuid-extension already exists

### DIFF
--- a/users-postgresql-simple/src/Web/Users/Postgresql.hs
+++ b/users-postgresql-simple/src/Web/Users/Postgresql.hs
@@ -111,7 +111,7 @@ getOrderBy sb =
 instance UserStorageBackend Connection where
     type UserId Connection = Int64
     initUserBackend conn =
-        do unlessM (doesExtensionExist conn "uuid-ossp")
+        do unlessM (doesExtensionExist conn "uuid-ossp") $
               do _ <- execute_ conn [sql|CREATE EXTENSION "uuid-ossp";|]
                  return ()
            _ <- execute_ conn createUsersTable


### PR DESCRIPTION
Postgres requires superuser permissions to create the uuid-ossp
extension. By checking if it exists it's possible to create the
extension ahead of time, when creating the database, so that 'initUserBackend'
doesn't result in an error when using a database connection without
a superuser.